### PR TITLE
Правки для охранника РНД..

### DIFF
--- a/maps/torch/items/cards_ids.dm
+++ b/maps/torch/items/cards_ids.dm
@@ -206,6 +206,7 @@
 	extra_details = list("onegoldstripe")
 
 /obj/item/card/id/torch/passenger/corporate/corporate_guard
+	desc = "A card issued to corporate personnel aboard the SEV Torch."
 	job_access_type = /datum/job/corporate_guard
 
 //Merchant

--- a/maps/torch/items/rigs.dm
+++ b/maps/torch/items/rigs.dm
@@ -365,12 +365,12 @@
 	icon_state = "hazard_rig"
 	armor = list(
 		melee = ARMOR_MELEE_MAJOR,
-		bullet = ARMOR_BALLISTIC_MINOR,
-		laser = ARMOR_LASER_MINOR,
-		energy = ARMOR_ENERGY_MINOR,
+		bullet = ARMOR_BALLISTIC_SMALL,
+		laser = ARMOR_LASER_SMALL,
+		energy = ARMOR_ENERGY_SMALL,
 		bomb = ARMOR_BOMB_RESISTANT,
 		bio = ARMOR_BIO_SHIELDED,
-		rad = ARMOR_RAD_MINOR
+		rad = ARMOR_RAD_SMALL
 		)
 	online_slowdown = 2
 	offline_slowdown = 3

--- a/maps/torch/job/corporate_jobs.dm
+++ b/maps/torch/job/corporate_jobs.dm
@@ -54,8 +54,8 @@
 	                    SKILL_WEAPONS     = SKILL_ADEPT
 						)
 
-	max_skill = list(   SKILL_COMBAT      = SKILL_MAX,
-	                    SKILL_WEAPONS     = SKILL_MAX)
+	max_skill = list(   SKILL_COMBAT      = SKILL_EXPERT,
+	                    SKILL_WEAPONS     = SKILL_EXPERT)
 	skill_points = 20
 
 	access = list(

--- a/maps/torch/job/corporate_jobs.dm
+++ b/maps/torch/job/corporate_jobs.dm
@@ -42,7 +42,7 @@
 	spawn_positions = 1
 	supervisors = "the Chief Science Officer"
 	selection_color = "#473d63"
-	economic_power = 18
+	economic_power = 5
 	minimal_player_age = 0
 	minimum_character_age = list(SPECIES_HUMAN = 26)
 	outfit_type = /decl/hierarchy/outfit/job/torch/passenger/corporate_guard

--- a/maps/torch/job/corporate_jobs.dm
+++ b/maps/torch/job/corporate_jobs.dm
@@ -40,7 +40,7 @@
 	department_flag = SCI
 	total_positions = 1
 	spawn_positions = 1
-	supervisors = "the Chief Science Officer and Corporate Liason"
+	supervisors = "the Chief Science Officer"
 	selection_color = "#473d63"
 	economic_power = 18
 	minimal_player_age = 0
@@ -54,8 +54,8 @@
 	                    SKILL_WEAPONS     = SKILL_ADEPT
 						)
 
-	max_skill = list(   SKILL_COMBAT      = SKILL_EXPERT,
-	                    SKILL_WEAPONS     = SKILL_EXPERT)
+	max_skill = list(   SKILL_COMBAT      = SKILL_MAX,
+	                    SKILL_WEAPONS     = SKILL_MAX)
 	skill_points = 20
 
 	access = list(

--- a/maps/torch/loadout/loadout_head.dm
+++ b/maps/torch/loadout/loadout_head.dm
@@ -101,7 +101,7 @@
 	allowed_roles = TECHNICAL_ROLES
 
 /datum/gear/tactical/balaclava
-	allowed_roles = SECURITY_ROLES
+	allowed_roles = list(/datum/job/hos, /datum/job/warden, /datum/job/detective, /datum/job/officer, /datum/job/corporate_guard)
 
 /datum/gear/head/fleetberet
 	display_name = "Fleet branch beret selection"

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -21773,7 +21773,9 @@
 	dir = 1
 	},
 /obj/machinery/pager/science{
-	pixel_x = -25
+	dir = 8;
+	pixel_x = -10;
+	pixel_y = -25
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/entry)
@@ -23221,10 +23223,14 @@
 /area/thruster/d1starboard)
 "nAb" = (
 /obj/structure/table/standard,
-/obj/item/device/flashlight/lamp,
+/obj/item/device/flashlight/lamp{
+	pixel_x = -4;
+	pixel_y = -1
+	},
 /obj/effect/floor_decal/corner/red{
 	dir = 5
 	},
+/obj/machinery/recharger,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/rnd_sec)
 "nAp" = (
@@ -23527,6 +23533,12 @@
 	},
 /obj/effect/floor_decal/corner/research{
 	dir = 10
+	},
+/obj/machinery/button/blast_door{
+	dir = 1;
+	id_tag = "d1ladderwindow";
+	name = "Ladderwell Shutter Control";
+	pixel_y = -25
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
@@ -23840,10 +23852,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/command/armoury)
 "oox" = (
-/obj/effect/floor_decal/corner/research,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
 /obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+	pixel_y = 20
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
@@ -50909,7 +50922,7 @@ agU
 leb
 hcb
 hfb
-oox
+rvY
 ijb
 hAb
 aJv
@@ -51109,7 +51122,7 @@ agH
 agx
 oLK
 leb
-ivT
+oox
 hgb
 flB
 nPb

--- a/maps/torch/torch_antagonism.dm
+++ b/maps/torch/torch_antagonism.dm
@@ -1,7 +1,7 @@
 //Makes sure we don't get any merchant antags as a balance concern. Can also be used for future Torch specific antag restrictions.
 /datum/antagonist/changeling
 	blacklisted_jobs = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant, /datum/job/captain, /datum/job/hop, /datum/job/submap)
-	protected_jobs = list(/datum/job/medical_trainee, /datum/job/engineer_trainee, /datum/job/junior_doctor)
+	protected_jobs = list(/datum/job/medical_trainee, /datum/job/engineer_trainee, /datum/job/junior_doctor, /datum/job/corporate_guard)
 
 /datum/antagonist/godcultist
 	blacklisted_jobs = list(/datum/job/ai, /datum/job/cyborg, /datum/job/chaplain, /datum/job/merchant, /datum/job/captain, /datum/job/hop, /datum/job/hos, /datum/job/submap)
@@ -9,7 +9,7 @@
 
 /datum/antagonist/cultist
 	blacklisted_jobs = list(/datum/job/ai, /datum/job/cyborg, /datum/job/chaplain, /datum/job/psychiatrist, /datum/job/merchant, /datum/job/captain, /datum/job/hop, /datum/job/hos, /datum/job/submap)
-	protected_jobs = list(/datum/job/medical_trainee, /datum/job/engineer_trainee, /datum/job/junior_doctor)
+	protected_jobs = list(/datum/job/medical_trainee, /datum/job/engineer_trainee, /datum/job/junior_doctor, /datum/job/corporate_guard)
 
 /datum/antagonist/loyalists
 	blacklisted_jobs = list(/datum/job/ai, /datum/job/cyborg, /datum/job/submap, /datum/job/merchant)
@@ -18,10 +18,10 @@
 /datum/antagonist/revolutionary
 	blacklisted_jobs = list(/datum/job/ai, /datum/job/cyborg, /datum/job/submap, /datum/job/merchant)
 	restricted_jobs = list(/datum/job/captain, /datum/job/hop)
-	protected_jobs = list(/datum/job/officer, /datum/job/medical_trainee, /datum/job/engineer_trainee, /datum/job/junior_doctor)
+	protected_jobs = list(/datum/job/officer, /datum/job/medical_trainee, /datum/job/engineer_trainee, /datum/job/junior_doctor, /datum/job/corporate_guard)
 
 /datum/antagonist/traitor
-	blacklisted_jobs = list(/datum/job/merchant, /datum/job/captain, /datum/job/hop, /datum/job/ai, /datum/job/submap, /datum/job/hos, /datum/job/medical_trainee, /datum/job/engineer_trainee, /datum/job/junior_doctor)
+	blacklisted_jobs = list(/datum/job/merchant, /datum/job/captain, /datum/job/hop, /datum/job/ai, /datum/job/submap, /datum/job/hos, /datum/job/medical_trainee, /datum/job/engineer_trainee, /datum/job/junior_doctor, /datum/job/corporate_guard)
 
 /datum/antagonist/ert
 	var/sic //Second-In-Command


### PR DESCRIPTION
- Чиним описание карты
- Немного увеличиваем характеристики рига. Теперь он наравне с ригом ГСБ, уступая тому только в плане защиты от балистики.
- Теперь охранник может взять балаклаву, а также мастера ДБ и ББ
- Добавляем зарядник в офис
- И охраник теперь не может быть антагом, но культи его смогут конвертнуть