### PR TITLE
Перевод, дополненение и исправление эмоутов и эмоут-панель

### DIFF
--- a/code/game/verbs/emotions.dm
+++ b/code/game/verbs/emotions.dm
@@ -20,15 +20,15 @@
 	set category = "Emote"
 	emote("giggle")
 
-/mob/living/verb/scream()
-	set name = "Кричать"
-	set category = "Emote"
-	emote("scream")
-
 /mob/living/verb/scratch()
 	set name = "Почесаться"
 	set category = "Emote"
 	emote("scratch")
+
+/mob/living/verb/scream()
+	set name = "Кричать"
+	set category = "Emote"
+	emote("scream")
 
 /mob/living/verb/blush()
 	set name = "Краснеть"
@@ -96,9 +96,14 @@
 	emote("gasp")
 
 /mob/living/verb/glare()
-	set name = "Смотреть с ненавистью"
+	set name = "Недовольно смотреть"
 	set category = "Emote"
 	emote("glare")
+
+/mob/living/verb/tfist()
+	set name = "Сжать руки в кулаки"
+	set category = "Emote"
+	emote("tfist")
 
 /mob/living/verb/groan()
 	set name = "Болезненный стон"
@@ -165,6 +170,11 @@
 	set category = "Emote"
 	emote("shrug")
 
+/mob/living/verb/hshrug()
+	set name = "Слегка пожать плечами"
+	set category = "Emote"
+	emote("hshrug")
+
 /mob/living/verb/stare()
 	set name = "Пялиться"
 	set category = "Emote"
@@ -215,10 +225,20 @@
 	set category = "Emote"
 	emote("salute")
 
+/mob/living/verb/rsalute()
+	set name = "Ответить на воинское приветствие"
+	set category = "Emote"
+	emote("rsalute")
+
 /mob/living/verb/eyebrow()
 	set name = "Приподнять бровь"
 	set category = "Emote"
 	emote("eyebrow")
+
+/mob/living/verb/alook()
+	set name = "Отвести взгляд"
+	set category = "Emote"
+	emote("alook")
 
 /mob/living/verb/snap()
 	set name = "Щёлкнуть пальцами"

--- a/code/modules/emotes/definitions/_mob.dm
+++ b/code/modules/emotes/definitions/_mob.dm
@@ -36,7 +36,6 @@
 		/decl/emote/audible/deathgasp_alien,
 		/decl/emote/audible/whimper,
 		/decl/emote/audible/gasp,
-		/decl/emote/audible/scretch,
 		/decl/emote/audible/choke,
 		/decl/emote/audible/moan,
 		/decl/emote/audible/gnarl
@@ -59,7 +58,7 @@
 		/decl/emote/visible/collapse,
 		/decl/emote/audible/hiss,
 		/decl/emote/audible,
-		/decl/emote/audible/scretch,
+		/decl/emote/visible/scratch,
 		/decl/emote/audible/choke,
 		/decl/emote/audible/gnarl,
 		/decl/emote/audible/bug_hiss,
@@ -84,7 +83,9 @@
 
 /mob/living/carbon/human
 	default_emotes = list(
+		/decl/emote/visible/adjust,
 		/decl/emote/visible/blink,
+		/decl/emote/visible/scratch,
 		/decl/emote/audible/synth,
 		/decl/emote/audible/synth/ping,
 		/decl/emote/audible/synth/buzz,
@@ -166,7 +167,6 @@
 		/decl/emote/visible/squint,
 		/decl/emote/visible/tfist,
 		/decl/emote/visible/tilt,
-		/decl/emote/visible/adjust,
 //[INF],
 		/decl/emote/audible/finger_snap,
 //[/INF],

--- a/code/modules/emotes/definitions/adherent.dm
+++ b/code/modules/emotes/definitions/adherent.dm
@@ -1,9 +1,9 @@
 /decl/emote/audible/adherent_ding
 	key = "ding"
-	emote_message_3p = "USER dings."
+	emote_message_3p = "USER звенит."
 	emote_sound = 'sound/effects/ding2.ogg'
 
 /decl/emote/audible/adherent_chime
 	key = "chime"
-	emote_message_3p = "USER chimes."
+	emote_message_3p = "USER издаёт колокольный звон."
 	emote_sound = 'sound/voice/chime.ogg'

--- a/code/modules/emotes/definitions/audible.dm
+++ b/code/modules/emotes/definitions/audible.dm
@@ -1,20 +1,16 @@
 /decl/emote/audible
 	key = "burp"
-	emote_message_3p = "USER burps."
+	emote_message_3p = "USER отрыгается."
 	message_type = AUDIBLE_MESSAGE
 
 /decl/emote/audible/deathgasp_alien
 	key = "deathgasp"
-	emote_message_3p = "USER lets out a waning guttural screech, green blood bubbling from its maw."
+	emote_message_3p = "USER издает слабеющий гортанный визг, зеленая кровь пузырится из его пасти."
 
 /decl/emote/audible/gasp
 	key ="gasp"
 	emote_message_3p = "USER задыхается!"
 	conscious = 0
-
-/decl/emote/audible/scretch
-	key ="scretch"
-	emote_message_3p = "USER чешется."
 
 /decl/emote/audible/choke
 	key ="choke"
@@ -23,7 +19,7 @@
 
 /decl/emote/audible/gnarl
 	key ="gnarl"
-	emote_message_3p = "USER gnarls and shows its teeth.."
+	emote_message_3p = "USER скалится и показывает свои зубы."
 
 /decl/emote/audible/chirp
 	key ="chirp"
@@ -32,23 +28,23 @@
 
 /decl/emote/audible/multichirp
 	key ="mchirp"
-	emote_message_3p = "USER chirps a chorus of notes!"
+	emote_message_3p = "USER щебечет хор нот!"
 	emote_sound = 'sound/misc/multichirp.ogg'
 
 /decl/emote/audible/alarm
 	key = "alarm"
-	emote_message_1p = "You sound an alarm."
-	emote_message_3p = "USER sounds an alarm."
+	emote_message_1p = "You подал сигнал тревоги."
+	emote_message_3p = "USER подаёт сигнал тревоги."
 
 /decl/emote/audible/alert
 	key = "alert"
-	emote_message_1p = "You let out a distressed noise."
-	emote_message_3p = "USER lets out a distressed noise."
+	emote_message_1p = "You издаёте огорченный звук."
+	emote_message_3p = "USER издал огорченный звук."
 
 /decl/emote/audible/notice
 	key = "notice"
-	emote_message_1p = "You play a loud tone."
-	emote_message_3p = "USER plays a loud tone."
+	emote_message_1p = "You включаете громкий сигнал."
+	emote_message_3p = "USER проигрывает громкий сигнал."
 
 /decl/emote/audible/whistle
 	key = "whistle"
@@ -144,10 +140,10 @@
 
 /decl/emote/audible/slap
 	key = "slap"
-	emote_message_1p_target = "You slap TARGET across the face!"
-	emote_message_1p = "You slap yourself across the face!"
-	emote_message_3p_target = "USER slaps TARGET across the face!"
-	emote_message_3p = "USER slaps USER_SELF across the face!"
+	emote_message_1p_target = "Ты бьёшь TARGET по лицу!"
+	emote_message_1p = "Ты бьёшь себя по лицу!"
+	emote_message_3p_target = "USER бьёт TARGET по лицу!"
+	emote_message_3p = "USER бьёт USER_SELF по лицу!"
 	emote_sound = 'sound/effects/snap.ogg'
 	check_restraints = TRUE
 	check_range = 1
@@ -170,12 +166,12 @@
 
 /decl/emote/audible/vox_shriek
 	key ="shriek"
-	emote_message_3p = "USER SHRIEKS!"
+	emote_message_3p = "USER ВИЗЖИТ!"
 	emote_sound = 'sound/voice/shriek1.ogg'
 
 /decl/emote/audible/roar
 	key = "roar"
-	emote_message_3p = "USER roars!"
+	emote_message_3p = "USER рычит!"
 
 /decl/emote/audible/bellow
 	key = "bellow"
@@ -183,16 +179,16 @@
 
 /decl/emote/audible/howl
 	key = "howl"
-	emote_message_3p = "USER howls!"
+	emote_message_3p = "USER воет!"
 
 /decl/emote/audible/wheeze
 	key = "wheeze"
-	emote_message_3p = "USER wheezes."
+	emote_message_3p = "USER хрипит."
 
 /decl/emote/audible/hiss
 	key ="hiss_"
-	emote_message_3p_target = "USER hisses softly at TARGET."
-	emote_message_3p = "USER hisses softly."
+	emote_message_3p_target = "USER тихо шипит на TARGET."
+	emote_message_3p = "USER тихо шипит."
 
 /decl/emote/audible/lizard_bellow
 	key = "bellow"
@@ -202,7 +198,7 @@
 
 /decl/emote/audible/lizard_squeal
 	key = "squeal"
-	emote_message_3p = "USER squeals."
+	emote_message_3p = "USER пищит."
 	emote_sound = 'sound/voice/LizardSqueal.ogg'
 
 /decl/emote/audible/gasp

--- a/code/modules/emotes/definitions/exertion.dm
+++ b/code/modules/emotes/definitions/exertion.dm
@@ -2,8 +2,8 @@
 /decl/emote/exertion/biological
 	key = "esweat"
 	emote_range = 4
-	emote_message_1p = "You are sweating heavily."
-	emote_message_3p = "USER is sweating heavily."
+	emote_message_1p = "Вы сильно потеете."
+	emote_message_3p = "USER сильно потеет."
 
 /decl/emote/exertion/biological/check_user(mob/living/user)
 	if(istype(user) && !user.isSynthetic())
@@ -27,8 +27,8 @@
 	key = "ewhine"
 	emote_range = 3
 	message_type = AUDIBLE_MESSAGE
-	emote_message_1p = "You overstress your actuators."
-	emote_message_3p = "USER's actuators whine with strain."
+	emote_message_1p = "Вы перегрузили свои приводы."
+	emote_message_3p = "USER's приводы становятся белыми от напряжения."
 
 /decl/emote/exertion/synthetic/check_user(mob/living/user)
 	if(istype(user) && user.isSynthetic())
@@ -37,5 +37,5 @@
 
 /decl/emote/exertion/synthetic/creak
 	key = "ecreak"
-	emote_message_1p = "Your chassis stress indicators spike."
+	emote_message_1p = "Показатели нагрузки на шасси резко возрастают."
 	emote_message_3p = "USER's joints creak with stress."

--- a/code/modules/emotes/definitions/synthetics.dm
+++ b/code/modules/emotes/definitions/synthetics.dm
@@ -1,6 +1,6 @@
 /decl/emote/audible/synth
 	key = "beep"
-	emote_message_3p = "USER beeps."
+	emote_message_3p = "USER издаёт звуковые сигналы."
 	emote_sound = 'sound/machines/twobeep.ogg'
 
 /decl/emote/audible/synth/check_user(var/mob/living/user)
@@ -10,22 +10,22 @@
 
 /decl/emote/audible/synth/ping
 	key = "ping"
-	emote_message_3p = "USER pings."
+	emote_message_3p = "USER издаёт громкий звон."
 	emote_sound = 'sound/machines/ping.ogg'
 
 /decl/emote/audible/synth/buzz
 	key = "buzz"
-	emote_message_3p = "USER buzzes."
+	emote_message_3p = "USER издаёт жужжащий звук."
 	emote_sound = 'sound/machines/buzz-sigh.ogg'
 
 /decl/emote/audible/synth/confirm
 	key = "confirm"
-	emote_message_3p = "USER emits an affirmative blip."
+	emote_message_3p = "USER выдает утвердительный сигнал."
 	emote_sound = 'sound/machines/synth_yes.ogg'
 
 /decl/emote/audible/synth/deny
 	key = "deny"
-	emote_message_3p = "USER emits a negative blip."
+	emote_message_3p = "USER выдает отрицательный сигнал."
 	emote_sound = 'sound/machines/synth_no.ogg'
 
 /decl/emote/audible/synth/security

--- a/code/modules/emotes/definitions/synthetics.dm
+++ b/code/modules/emotes/definitions/synthetics.dm
@@ -1,6 +1,6 @@
 /decl/emote/audible/synth
 	key = "beep"
-	emote_message_3p = "USER издаёт звуковые сигналы."
+	emote_message_3p = "USER пиликает."
 	emote_sound = 'sound/machines/twobeep.ogg'
 
 /decl/emote/audible/synth/check_user(var/mob/living/user)
@@ -10,22 +10,22 @@
 
 /decl/emote/audible/synth/ping
 	key = "ping"
-	emote_message_3p = "USER издаёт громкий звон."
+	emote_message_3p = "USER издаёт сигнал запроса."
 	emote_sound = 'sound/machines/ping.ogg'
 
 /decl/emote/audible/synth/buzz
 	key = "buzz"
-	emote_message_3p = "USER издаёт жужжащий звук."
+	emote_message_3p = "USER издает жужжащие звуки."
 	emote_sound = 'sound/machines/buzz-sigh.ogg'
 
 /decl/emote/audible/synth/confirm
 	key = "confirm"
-	emote_message_3p = "USER выдает утвердительный сигнал."
+	emote_message_3p = "USER посылает положительный сигнал."
 	emote_sound = 'sound/machines/synth_yes.ogg'
 
 /decl/emote/audible/synth/deny
 	key = "deny"
-	emote_message_3p = "USER выдает отрицательный сигнал."
+	emote_message_3p = "USER посылает отрицательный сигнал."
 	emote_sound = 'sound/machines/synth_no.ogg'
 
 /decl/emote/audible/synth/security

--- a/code/modules/emotes/definitions/visible.dm
+++ b/code/modules/emotes/definitions/visible.dm
@@ -6,7 +6,7 @@
 /decl/emote/visible/scratch
 	key = "scratch"
 	check_restraints = TRUE
-	emote_message_3p = "USER чешется."
+	emote_message_3p = "USER почёсывается."
 
 /decl/emote/visible/drool
 	key ="drool"
@@ -63,7 +63,7 @@
 
 /decl/emote/visible/flash
 	key = "flash"
-	emote_message_3p = "The lights on USER flash quickly."
+	emote_message_3p = "Индикаторы на дисплее USER быстро мигают."
 
 /decl/emote/visible/blink
 	key = "blink"
@@ -72,7 +72,7 @@
 /decl/emote/visible/airguitar
 	key = "airguitar"
 	check_restraints = TRUE
-	emote_message_3p = "USER is strumming the air and headbanging like a safari chimp."
+	emote_message_3p = "USER бренчит в воздухе и мотает головой, как шимпанзе на сафари."
 
 /decl/emote/visible/blink_r
 	key = "blink_r"
@@ -210,7 +210,7 @@
 
 /decl/emote/visible/lightup
 	key = "light"
-	emote_message_3p = "USER lights up for a bit, then stops."
+	emote_message_3p = "USER загорается на некоторое время, затем прекращая светиться."
 
 /decl/emote/visible/vibrate
 	key = "vibrate"
@@ -234,8 +234,8 @@
 
 /decl/emote/visible/signal
 	key = "signal"
-	emote_message_3p_target = "USER signals at TARGET."
-	emote_message_3p = "USER signals."
+	emote_message_3p_target = "USER сигнализирует рукой TARGET."
+	emote_message_3p = "USER подаёт сигналы рукой."
 	check_restraints = TRUE
 
 /decl/emote/visible/signal/check_user(atom/user)
@@ -255,7 +255,7 @@
 
 /decl/emote/visible/alook
 	key = "alook"
-	emote_message_3p = "USER looks away."
+	emote_message_3p = "USER отводит взгляд."
 
 /decl/emote/visible/hbow
 	key = "hbow"
@@ -273,7 +273,7 @@
 
 /decl/emote/visible/hshrug
 	key = "hshrug"
-	emote_message_3p = "USER gives a half shrug."
+	emote_message_3p = "USER слегка пожимает плечами."
 
 /decl/emote/visible/crub
 	key = "crub"
@@ -317,7 +317,7 @@
 /decl/emote/visible/rsalute
 	key = "rsalute"
 	check_restraints = TRUE
-	emote_message_3p = "USER returns the salute."
+	emote_message_3p = "USER отвечает на воинское приветствие."
 
 /decl/emote/visible/rshoulder
 	key = "rshoulder"
@@ -325,8 +325,8 @@
 
 /decl/emote/visible/squint
 	key = "squint"
-	emote_message_3p = "USER squints."
-	emote_message_3p_target = "USER squints at TARGET."
+	emote_message_3p = "USER прищуривается."
+	emote_message_3p_target = "USER прищуривается на TARGET."
 
 /decl/emote/visible/tfist
 	key = "tfist"
@@ -341,4 +341,5 @@
 
 /decl/emote/visible/adjust
 	key = "adjust"
-	emote_message_3p = "USER поправляет снаряжение"
+	emote_message_3p = "USER поправляет одежду."
+	emote_message_3p_target = "USER поправляет одежду TARGET."

--- a/code/modules/emotes/definitions/visible.dm
+++ b/code/modules/emotes/definitions/visible.dm
@@ -341,5 +341,6 @@
 
 /decl/emote/visible/adjust
 	key = "adjust"
+	check_restraints = TRUE
 	emote_message_3p = "USER поправляет одежду."
 	emote_message_3p_target = "USER поправляет одежду TARGET."

--- a/code/modules/emotes/definitions/vox.dm
+++ b/code/modules/emotes/definitions/vox.dm
@@ -1,9 +1,9 @@
 /decl/emote/audible/vox_shriek
 	key ="shriek"
-	emote_message_3p = "USER SHRIEKS!"
+	emote_message_3p = "USER ВИЗЖИТ!"
 	emote_sound = 'sound/voice/shriek1.ogg'
 
 /decl/emote/audible/armalis_shriek
 	key ="ashriek"
-	emote_message_3p = "USER horrifyingly SHRIEKS!"
+	emote_message_3p = "USER ужасающе ВИЗЖИТ!"
 	emote_sound = 'sound/voice/ashriek.ogg'

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -9,7 +9,7 @@
 	slot_flags = SLOT_BACK
 	origin_tech = list(TECH_COMBAT = 8, TECH_MATERIAL = 2, TECH_ESOTERIC = 8)
 	caliber = CALIBER_ANTIMATERIAL
-	screen_shake = 3 //extra kickback
+	screen_shake = 2 //extra kickback
 	handle_casings = HOLD_CASINGS
 	load_method = SINGLE_CASING
 	max_shells = 1


### PR DESCRIPTION
:cl:
rscadd: Частичный перевод расовых и общих эмоутов, исключая те, где используются местоимения куклы.
rscadd: Обновлена панель эмоутов. Добавлены "tfist" и "rsalute". Только "rsalute" был переведён.
bugfix: Исправлено отображение эмоута "Черешется", но взамен него было установлено "Почёсывается"...
/:cl: