### PR TITLE
Изменение в системе гостевых пропусков (№2)

### DIFF
--- a/code/game/machinery/computer/guestpass.dm
+++ b/code/game/machinery/computer/guestpass.dm
@@ -34,8 +34,8 @@
 	to_chat(usr, SPAN_NOTICE("Issuing reason: [reason]."))
 
 /obj/item/card/id/guest/proc/expire()
-	color = COLOR_BLACK
-	detail_color = COLOR_BLACK
+	color = COLOR_PALE_GREEN_GRAY
+	detail_color = COLOR_NT_RED
 	update_icon()
 
 	expired = TRUE
@@ -103,7 +103,7 @@
 				"selected" = (A in accesses))))
 
 		data["giver_access"] = giver_access
-		
+
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if(!ui)
 		ui = new(user, src, ui_key, "guestpass.tmpl", "Guest Pass Terminal", 600, 800)
@@ -128,9 +128,9 @@
 			. = TOPIC_REFRESH
 
 	else if (href_list["duration"])
-		var/dur = input(user, "Duration (in minutes) during which pass is valid (up to 60 minutes).", "Duration") as num|null
+		var/dur = input(user, "Duration (in minutes) during which pass is valid (up to 45 minutes).", "Duration") as num|null
 		if (dur && CanUseTopic(user, state))
-			if (dur > 0 && dur <= 30)
+			if (dur > 0 && dur <= 45)
 				duration = dur
 				. = TOPIC_REFRESH
 			else


### PR DESCRIPTION
<!--
**Это перевод оригинального темплейта с Baystation12/Baystation12**
Не забудьте добавить ченджлог, если вы сделали изменения, касающиеся админов/игроков, и которые могут повлиять на геймплей.

Примеры, когда необходимо добавить ченджлог:
* Добавление/удаление объектов с которыми игроки могут взаимодействовать, или их поведение.
* Добавление/удаление/изменение админских инструментов/кнопок.
* Изменения карты.

Примеры, когда записи в ченджлоге необязательны/не требуются:
* Косметические изменения, такие как описания, звуки и т.д.
* Оптимизация и другие подобные изменения базовых систем, не влияющие на геймплей.
* Небольшие багфиксы.

Вы можете найти README файл с подробными объяснениями в ./html/changelogs.
А ещё можно добавить свой ченджлог прямо в ПР. Инфа тут: https://github.com/Proxima-Project/Proxi-Bay12/wiki/Automatic-changelog-generation
-->
### Описание изменений
Время действия гостевых карт чуть расширено, как и исправлено описание при выборе времени (раньше было 30м - сейчас 45м). Вместе с тем, изменён цвет уже использованной гостевой карты - с чистого чёрного на серый с красными.
<!--
Здесь вы пишите, какой прекрасный йогурт вы сделали.
-->
### Почему и что этот ПР улучшит
Позволяет быстро отличить - можно ли использовать данную карту сейчас или нет, да и описание максимально возможного времени для действия карты более не путает.
<!--
Здесь вы пишите, почему ваш йогурт лучше чем тот, что был.
-->
### Чейнджлог
:cl: Exapster
rscadd: Изменено время действия гостевых карт - с тридцати минут на сорок пять минут.
rscadd: Изменён цвет использованной карты. С чистого чёрного - на серый с красными деталями.
bugfix: Исправлено отображение максимально возможного времени при конструирование гостевой карты.
/:cl:
<!--
Здесь вы пишите, если о новом йогурте должны узнать игроки. Пример смотрите в шапке
-->