### PR TITLE
Изменение в списке возможных печатаемых предметов автолатом

### DIFF
--- a/code/game/objects/items/devices/binoculars.dm
+++ b/code/game/objects/items/devices/binoculars.dm
@@ -5,6 +5,7 @@
 	zoomdevicename = "eyepieces"
 	icon = 'icons/obj/binoculars.dmi'
 	icon_state = "binoculars"
+	matter = list(MATERIAL_ALUMINIUM = 300,MATERIAL_GLASS = 60)
 
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
 	force = 5.0

--- a/code/game/objects/items/weapons/mop.dm
+++ b/code/game/objects/items/weapons/mop.dm
@@ -3,6 +3,7 @@
 	name = "mop"
 	icon = 'icons/obj/janitor.dmi'
 	icon_state = "mop"
+	matter = list(MATERIAL_STEEL = 60)
 	force = 5
 	throwforce = 10.0
 	throw_speed = 5

--- a/code/modules/fabrication/designs/general/designs_general.dm
+++ b/code/modules/fabrication/designs/general/designs_general.dm
@@ -1,6 +1,8 @@
 /datum/fabricator_recipe/bucket
 	path = /obj/item/reagent_containers/glass/bucket
 
+/datum/fabricator_recipe/mop
+	path = /obj/item/mop
 /datum/fabricator_recipe/flashlight
 	path = /obj/item/device/flashlight
 
@@ -18,6 +20,9 @@
 
 /datum/fabricator_recipe/radio_headset
 	path = /obj/item/device/radio/headset
+
+/datum/fabricator_recipe/binocular
+	path = /obj/item/device/binoculars
 
 /datum/fabricator_recipe/radio_bounced
 	path = /obj/item/device/radio/off


### PR DESCRIPTION
Отныне вы не останетесь без бинокля и швабры!

<!--
**Это перевод оригинального темплейта с Baystation12/Baystation12**
Не забудьте добавить ченджлог, если вы сделали изменения, касающиеся админов/игроков, и которые могут повлиять на геймплей.

Примеры, когда необходимо добавить ченджлог:
* Добавление/удаление объектов с которыми игроки могут взаимодействовать, или их поведение.
* Добавление/удаление/изменение админских инструментов/кнопок.
* Изменения карты.

Примеры, когда записи в ченджлоге необязательны/не требуются:
* Косметические изменения, такие как описания, звуки и т.д.
* Оптимизация и другие подобные изменения базовых систем, не влияющие на геймплей.
* Небольшие багфиксы.

Вы можете найти README файл с подробными объяснениями в ./html/changelogs.
А ещё можно добавить свой ченджлог прямо в ПР. Инфа тут: https://github.com/Proxima-Project/Proxi-Bay12/wiki/Automatic-changelog-generation
-->
### Описание изменений
• Автолат умеет печатать бинокли и швабры по цене. (стандартные детали)
Швабра: 75 стали.
Бинокль: 375 алюминия и 75 стекла.
### Почему и что этот ПР улучшит
Отныне не будет проблемой - где найти швабру. А бинокли вообще отдельная басня, так как их нужно было добавить в производство давным давно.
### Авторство
Exapster#5209
### Чейнджлог
:cl: Exapster
tweak: Теперь автолат (стандартного размера) умеет печатать и швабры, и бинокли!
/:cl:
#### Требуемые изменения на википедии проекта
Возможно потребуется обновить список печатаемых предметов через автолат на Вики, но не факт!