### PR TITLE
Parafix

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1471,14 +1471,10 @@ GLOBAL_VAR_INIT(skip_allow_lists, FALSE)
 			H.paralysis = 8000
 			H.admin_paralyzed = TRUE
 			msg = "has paralyzed [key_name(H)]."
-			H.visible_message(SPAN_DEBUG("OOC: \The [H] has been paralyzed by a staff member. Please hold all interactions with them until staff have finished with them."))
-			to_chat(H, SPAN_DEBUG("OOC: You have been paralyzed by a staff member. Please refer to your currently open admin help ticket or, if you don't have one, admin help for assistance."))
 		else
 			H.paralysis = 0
 			H.admin_paralyzed = FALSE
 			msg = "has unparalyzed [key_name(H)]."
-			H.visible_message(SPAN_DEBUG("OOC: \The [H] has been released from paralysis by staff. You may resume interactions with them."))
-			to_chat(H, SPAN_DEBUG("OOC: You have been released from paralysis by staff and can return to your game."))
 		log_and_message_staff(msg)
 
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -408,9 +408,6 @@ var/list/admin_verbs_xeno = list(
 		var/mob/observer/ghost/ghost = body.ghostize(1)
 		sound_to(usr, sound(null))
 
-		if (!ghost)
-			to_chat(src, FONT_COLORED("red", "You are already admin-ghosted."))
-			return
 		ghost.admin_ghosted = 1
 		if(body)
 			body.teleop = ghost

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -7,11 +7,6 @@
 
 	selected_image = image(icon('icons/misc/buildmode.dmi'), loc = src, icon_state = "ai_sel")
 
-/mob/living/examine(mob/user, distance, infix, suffix)
-	. = ..()
-	if (admin_paralyzed)
-		to_chat(user, SPAN_DEBUG("OOC: They have been paralyzed by staff. Please avoid interacting with them unless cleared to do so by staff."))
-
 //mob verbs are faster than object verbs. See mob/verb/examine.
 /mob/living/verb/pulled(atom/movable/AM as mob|obj in oview(1))
 	set name = "Pull"


### PR DESCRIPTION
### Описание изменений
Исправил баги в кнопках Aghost и Toggle Paralyze(Убрал тупое оповещение) у админов

### Почему и что этот ПР улучшит
Кнопка Aghost должна снова работать; Toggle paralyze больше не будет срать абсолютно лишними сообщениями игрокам в чат.

### Авторство

Donaldo_TH

### Чейнджлог

* Исправлены кнопки Aghost и Toggle Paralyze у админов
