### PR TITLE
Обновление званий КМП

### DIFF
--- a/maps/torch/items/clothing/solgov-accessory.dm
+++ b/maps/torch/items/clothing/solgov-accessory.dm
@@ -1056,7 +1056,7 @@ ranks - marines
 
 /obj/item/clothing/accessory/solgov/rank/army/officer/o3
 	name = "ranks (O-3 captain major)"
-	desc = "Collar pin denoting the rank of Marine Captain."
+	desc = "Collar pin denoting the rank of Captain Major."
 	icon_state = "o3_device"
 	overlay_state = "device_silver"
 
@@ -1079,10 +1079,9 @@ ranks - marines
 
 /obj/item/clothing/accessory/solgov/rank/army/flag
 	name = "ranks (O-7 colonel general)"
-	desc = "Collar pin denoting the rank of Major General."
+	desc = "Collar pin denoting the rank of Colonel General."
 	icon_state = "armyrank_command"
 
 /obj/item/clothing/accessory/solgov/rank/army/flag/o8
 	name = "ranks (O-8 general of the corps)"
-	desc = "Collar pin denoting the rank of Major General."
-	icon_state = "armyrank_command"
+	desc = "Collar pin denoting the rank of General of the Corps."

--- a/maps/torch/items/clothing/solgov-accessory.dm
+++ b/maps/torch/items/clothing/solgov-accessory.dm
@@ -1055,7 +1055,7 @@ ranks - marines
 	overlay_state = "device_silver"
 
 /obj/item/clothing/accessory/solgov/rank/army/officer/o3
-	name = "ranks (O-3 marine captain)"
+	name = "ranks (O-3 captain major)"
 	desc = "Collar pin denoting the rank of Marine Captain."
 	icon_state = "o3_device"
 	overlay_state = "device_silver"
@@ -1078,22 +1078,11 @@ ranks - marines
 	overlay_state = "device_silver"
 
 /obj/item/clothing/accessory/solgov/rank/army/flag
-	name = "ranks (O-7 brigadier general)"
-	desc = "Collar pin denoting the rank of Brigadier General."
+	name = "ranks (O-7 colonel general)"
+	desc = "Collar pin denoting the rank of Major General."
 	icon_state = "armyrank_command"
 
 /obj/item/clothing/accessory/solgov/rank/army/flag/o8
-	name = "ranks (O-8 major general)"
+	name = "ranks (O-8 general of the corps)"
 	desc = "Collar pin denoting the rank of Major General."
-
-/obj/item/clothing/accessory/solgov/rank/army/flag/o9
-	name = "ranks (O-9 lieutenant general)"
-	desc = "Collar pin denoting the rank of Lieutenant general."
-
-/obj/item/clothing/accessory/solgov/rank/army/flag/o10
-	name = "ranks (O-10 general)"
-	desc = "Collar pin denoting the rank of General."
-
-/obj/item/clothing/accessory/solgov/rank/army/flag/o10_alt
-	name = "ranks (O-10 general of the corps)"
-	desc = "Collar pin denoting the rank of General of the Corps."
+	icon_state = "armyrank_command"

--- a/maps/torch/torch_ranks.dm
+++ b/maps/torch/torch_ranks.dm
@@ -699,7 +699,7 @@
 	sort_order = 12
 
 /datum/mil_rank/army/o3
-	name = "Marine Captain"
+	name = "Captain Major"
 	name_short = "MCPT"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/army/officer/o3)
 	sort_order = 13
@@ -723,34 +723,16 @@
 	sort_order = 16
 
 /datum/mil_rank/army/o7
-	name = "Brigadier General"
-	name_short = "BGen"
+	name = "Colonel General"
+	name_short = "ColGen"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/army/flag)
 	sort_order = 17
 
 /datum/mil_rank/army/o8
-	name = "Major General"
-	name_short = "MajGen"
-	accessory = list(/obj/item/clothing/accessory/solgov/rank/army/flag/o8)
-	sort_order = 18
-
-/datum/mil_rank/army/o9
-	name = "Lieutenant General"
-	name_short = "LTG"
-	accessory = list(/obj/item/clothing/accessory/solgov/rank/army/flag/o9)
-	sort_order = 19
-
-/datum/mil_rank/army/o10
-	name = "General"
-	name_short = "GEN"
-	accessory = list(/obj/item/clothing/accessory/solgov/rank/army/flag/o10)
-	sort_order = 20
-
-/datum/mil_rank/army/o10_alt
 	name = "General of the Marine Corps"
 	name_short = "GenMarCor"
-	accessory = list(/obj/item/clothing/accessory/solgov/rank/army/flag/o10_alt)
-	sort_order = 20
+	accessory = list(/obj/item/clothing/accessory/solgov/rank/army/flag/o8)
+	sort_order = 18
 
 /*
  *  Civilians


### PR DESCRIPTION
### Чейнджлог
:cl: Exapster
rscdel: Два высших звания КМП были удалены из игры.
tweak: Капитан КМП стал Капитаном-Майором, сокращение в игре тоже самое.
/:cl:
<!--
<!--
Здесь вы пишите, если о новом йогурте должны узнать игроки. Пример смотрите в шапке
-->

