### PR TITLE
ЕЕЕЕ нормальный поинт-ту

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -353,6 +353,9 @@
 
 	var/obj/P = new /obj/effect/decal/point(tile)
 	P.set_invisibility(invisibility)
+	P.pixel_x = A.pixel_x
+	P.pixel_y = A.pixel_y
+	QDEL_IN(P, 2 SECONDS)
 	face_atom(A)
 	return 1
 


### PR DESCRIPTION
### Описание изменений

Теперь эта стрелка указывает именно на предмет, а не в центер тайла
### Почему и что этот ПР улучшит

Отменит ебланскую стрелку в центре, теперь стрелка будет всегда показывать на предмет
### Авторство

Авторк мега-кражи - Foler
### Чейнджлог

Поинт ту для нормальных
#### Требуемые изменения на википедии проекта

