### PR TITLE
Убийство эскадрильи и псиопа дионей

### DIFF
--- a/maps/torch/job/torch_jobs.dm
+++ b/maps/torch/job/torch_jobs.dm
@@ -14,7 +14,7 @@
 		/datum/species/unathi  = list(HUMAN_ONLY_JOBS, /datum/job/liaison, /datum/job/warden, /datum/job/synthetic), //Other jobs unavailable via branch restrictions,
 		/datum/species/unathi/yeosa = list(HUMAN_ONLY_JOBS, /datum/job/liaison, /datum/job/warden, /datum/job/synthetic),
 		/datum/species/skrell  = list(HUMAN_ONLY_JOBS, /datum/job/synthetic),
-		/datum/species/machine = list(/datum/job/liaison, /datum/job/psychiatrist, /datum/job/synthetic),
+		/datum/species/machine = list(/datum/job/liaison, /datum/job/psychiatrist, /datum/job/chaplain, /datum/job/detective /datum/job/synthetic),
 		/datum/species/machine/shell   = list(/datum/job/liaison, /datum/job/psychiatrist, /datum/job/officer, /datum/job/warden),
 		/datum/species/diona   = list(HUMAN_ONLY_JOBS, /datum/job/chaplain, /datum/job/detective, /datum/job/research_guard, /datum/job/nt_pilot, /datum/job/psychiatrist, /datum/job/officer, /datum/job/liaison, /datum/job/warden, /datum/job/doctor, /datum/job/medical_trainee, /datum/job/synthetic),	//Other jobs unavailable via branch restrictions,
 		/datum/species/human/gravworlder = list(/datum/job/synthetic),

--- a/maps/torch/job/torch_jobs.dm
+++ b/maps/torch/job/torch_jobs.dm
@@ -16,7 +16,7 @@
 		/datum/species/skrell  = list(HUMAN_ONLY_JOBS, /datum/job/synthetic),
 		/datum/species/machine = list(/datum/job/liaison, /datum/job/psychiatrist, /datum/job/synthetic),
 		/datum/species/machine/shell   = list(/datum/job/liaison, /datum/job/psychiatrist, /datum/job/officer, /datum/job/warden),
-		/datum/species/diona   = list(HUMAN_ONLY_JOBS, /datum/job/research_guard, /datum/job/nt_pilot, /datum/job/psychiatrist, /datum/job/officer, /datum/job/liaison, /datum/job/warden, /datum/job/doctor, /datum/job/medical_trainee, /datum/job/synthetic),	//Other jobs unavailable via branch restrictions,
+		/datum/species/diona   = list(HUMAN_ONLY_JOBS, /datum/job/chaplain, /datum/job/detective, /datum/job/research_guard, /datum/job/nt_pilot, /datum/job/psychiatrist, /datum/job/officer, /datum/job/liaison, /datum/job/warden, /datum/job/doctor, /datum/job/medical_trainee, /datum/job/synthetic),	//Other jobs unavailable via branch restrictions,
 		/datum/species/human/gravworlder = list(/datum/job/synthetic),
 		/datum/species/human/spacer = list(/datum/job/synthetic),
 		/datum/species/human/vatgrown = list(/datum/job/synthetic),

--- a/maps/torch/job/torch_jobs.dm
+++ b/maps/torch/job/torch_jobs.dm
@@ -16,7 +16,7 @@
 		/datum/species/skrell  = list(HUMAN_ONLY_JOBS, /datum/job/synthetic),
 		/datum/species/machine = list(/datum/job/liaison, /datum/job/psychiatrist, /datum/job/synthetic),
 		/datum/species/machine/shell   = list(/datum/job/liaison, /datum/job/psychiatrist, /datum/job/officer, /datum/job/warden),
-		/datum/species/diona   = list(HUMAN_ONLY_JOBS, /datum/job/research_guard, /datum/job/officer, /datum/job/liaison, /datum/job/warden, /datum/job/doctor, /datum/job/medical_trainee, /datum/job/synthetic),	//Other jobs unavailable via branch restrictions,
+		/datum/species/diona   = list(HUMAN_ONLY_JOBS, /datum/job/research_guard, /datum/job/nt_pilot, /datum/job/psychiatrist, /datum/job/officer, /datum/job/liaison, /datum/job/warden, /datum/job/doctor, /datum/job/medical_trainee, /datum/job/synthetic),	//Other jobs unavailable via branch restrictions,
 		/datum/species/human/gravworlder = list(/datum/job/synthetic),
 		/datum/species/human/spacer = list(/datum/job/synthetic),
 		/datum/species/human/vatgrown = list(/datum/job/synthetic),


### PR DESCRIPTION
### Описание изменений

Невероятно обрезал дионам пилота и псионика.
Почему?
Потому что дионы не умеют играть в майкрософт флай симулятор. 
А ещё они качались в биологическое возвышение а не в псионическое.

### Почему и что этот ПР улучшит

Уберегаем торч от профессиональных пилотов с пятисекундными задержками между маневрами на овермапе.
А ещё спасаем  бедных лороведов от споров касательно псионической силы дион.
### Авторство

ЯЙЦО
### Чейнджлог

Дионы теряют пилота и псионика.

#### Требуемые изменения на википедии проекта

Ничего????